### PR TITLE
Add ScssPhpMethodTest. Fix php-method callback.

### DIFF
--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -17,7 +17,7 @@ composer compile:list [-v[v]] [--json]
 
 For further details, see the built-in `--help` screen.
 
-## Example: composer.json
+## Example: Shell-based task
 
 Suppose you publish a library (package), `foo/bar`, which includes a handful of JS files and CSS files. You want to ensure that
 an aggregated file is available. This example would produce two aggregate files, `all.js` and `all.css`.
@@ -45,34 +45,42 @@ Observe that:
 * It does not matter if `foo/bar` is a root-project.
 * Compiled files should not be committed to the origin/git project.
 
-<!--
-For the next example, we seek to build a custom variant of Bootstrap.
+## Example: PHP-based task
+
+For the next example, we declare a PHP-based task to compile some SCSS.
 
 ```json
 {
   "name": "foo/bar",
   "require": {
-    "civicrm/composer-compile-plugin": "~1.0",
-    "scssphp/scssphp": "~1.2",
-    "twbs/bootstrap": "~4.5.2"
+    "civicrm/composer-compile-plugin": "@dev",
+    "scssphp/scssphp": "1.2.0",
+    "padaliyajay/php-autoprefixer": "~1.2"
   },
-  "autoload": {
-    "psr-4": {
-      "MyTheme\\": "src/"
-    }
-  },
+  "autoload": {"psr-4": {"ScssExample\\": "src"}},
   "extra": {
-    "compile": [
-      {
-        "title": "Compile <comment>*.css</comment => <comment>*.scss</comment>"
-        "callback": "\MyTheme\Compile::compileCss",
-        "watch": ["scss/*"]
-      }
-    ]
+    "compile": [{"php-method": "\\ScssExample\\ScssExample::make"}]
   }
 }
 ```
--->
+
+The method goes in `src/ScssExample.php`:
+
+```php
+namespace ScssExample;
+class ScssExample
+{
+  public static function make(array $task)
+  {
+    $pkgDir = dirname(__DIR__);
+    $scssCompiler = new \ScssPhp\ScssPhp\Compiler();
+    $scss = 'div { .foo { hyphens: auto; } }';
+    $css = $scssCompiler->compile($scss);
+    $autoprefixer = new \Padaliyajay\PHPAutoprefixer\Autoprefixer($css);
+    file_put_contents("$pkgDir/build.css", $autoprefixer->compile());
+  }
+}
+```
 
 ## Task Specification
 

--- a/src/CompilePlugin.php
+++ b/src/CompilePlugin.php
@@ -4,6 +4,7 @@ namespace Civi\CompilePlugin;
 
 use Civi\CompilePlugin\Command\CompileListCommand;
 use Civi\CompilePlugin\Event\CompileEvents;
+use Civi\CompilePlugin\Subscriber\PhpSubscriber;
 use Civi\CompilePlugin\Subscriber\ShellSubscriber;
 use Civi\CompilePlugin\Util\TaskUIHelper;
 use Composer\Composer;
@@ -54,6 +55,7 @@ class CompilePlugin implements PluginInterface, EventSubscriberInterface, Capabl
         $this->io = $io;
         $dispatch = $composer->getEventDispatcher();
         $dispatch->addListener(CompileEvents::POST_COMPILE_LIST, [ShellSubscriber::class, 'applyDefaultCallback']);
+        $dispatch->addListener(CompileEvents::POST_COMPILE_LIST, [PhpSubscriber::class, 'applyDefaultCallback']);
     }
 
     public function deactivate(Composer $composer, IOInterface $io)
@@ -61,6 +63,7 @@ class CompilePlugin implements PluginInterface, EventSubscriberInterface, Capabl
         // NOTE: This method is only valid on composer v2.
         $dispatch = $composer->getEventDispatcher();
         $dispatch->removeListener(CompileEvents::POST_COMPILE_LIST, [ShellSubscriber::class, 'applyDefaultCallback']);
+        $dispatch->removeListener(CompileEvents::POST_COMPILE_LIST, [PhpSubscriber::class, 'applyDefaultCallback']);
     }
 
     public function uninstall(Composer $composer, IOInterface $io)

--- a/src/Subscriber/PhpSubscriber.php
+++ b/src/Subscriber/PhpSubscriber.php
@@ -4,27 +4,66 @@ namespace Civi\CompilePlugin\Subscriber;
 
 use Civi\CompilePlugin\Event\CompileListEvent;
 use Civi\CompilePlugin\Event\CompileTaskEvent;
-use Civi\CompilePlugin\Exception\TaskFailedException;
 use Civi\CompilePlugin\Task;
-use Composer\IO\IOInterface;
+use Civi\CompilePlugin\Util\ShellRunner;
 
 class PhpSubscriber
 {
 
-  /**
-   * When evaluating the tasks, any task with a 'php-method'
-   * property will (by default) by handled by us.
-   *
-   * @param \Civi\CompilePlugin\Event\CompileListEvent $e
-   */
+    /**
+     * When evaluating the tasks, any task with a 'php-method'
+     * property will (by default) by handled by us.
+     *
+     * @param \Civi\CompilePlugin\Event\CompileListEvent $e
+     */
     public static function applyDefaultCallback(CompileListEvent $e)
     {
         $tasks = $e->getTasks();
         foreach ($tasks as $task) {
           /** @var Task $task */
             if ($task->callback === null && isset($task->definition['php-method'])) {
-                $task->callback = $task->definition['php-method'];
+                $phpMethod = $task->definition['php-method'];
+                if (self::isWellFormedMethod($phpMethod)) {
+                    $task->callback = [static::CLASS, 'runTask'];
+                } else {
+                    throw new \InvalidArgumentException("Malformed callback");
+                }
             }
         }
+    }
+
+    public static function runTask(CompileTaskEvent $event)
+    {
+        // Surely there's a smarter way to get this?
+        $vendorPath = $event->getComposer()->getConfig()->get('vendor-dir');
+        $autoload =  $vendorPath . '/autoload.php';
+        if (!file_exists($autoload)) {
+            throw new \RuntimeException("CompilePlugin: Failed to locate autoload.php");
+        }
+        $cmd = '@php -r ' . escapeshellarg(sprintf(
+            'require_once %s; %s(%s);',
+            var_export($autoload, 1),
+            $event->getTask()->definition['php-method'],
+            var_export($event->getTask()->definition, 1)
+        ));
+
+        $r = new ShellRunner($event->getComposer(), $event->getIO());
+        $r->run($cmd);
+    }
+
+    /**
+     * @param string $phpMethod
+     * @return bool
+     */
+    private static function isWellFormedMethod($phpMethod)
+    {
+        if (!is_string($phpMethod)) {
+            return false;
+        }
+        $parts = explode('::', $phpMethod);
+        if (count($parts) > 2) {
+            return false;
+        }
+        return preg_match(';^[a-zA-Z0-9_\\\:]+$;', $phpMethod);
     }
 }

--- a/src/Task.php
+++ b/src/Task.php
@@ -140,7 +140,7 @@ class Task
             throw new \RuntimeException("Compilation task is missing field(s): " . implode(",", $missing));
         }
         if (!is_callable($this->callback)) {
-            throw new \RuntimeException("Compilation task has invalid callback: {$this->callback}");
+            throw new \RuntimeException("Compilation task has invalid callback: " . json_encode($this->callback));
         }
         return $this;
     }

--- a/tests/IntegrationTestCase.php
+++ b/tests/IntegrationTestCase.php
@@ -29,6 +29,13 @@ class IntegrationTestCase extends \PHPUnit\Framework\TestCase
               'type' => 'path',
               'url' => self::getPluginSourceDir() . '/tests/pkgs/cherry-jam',
             ],
+            'test-gnocchi' => [
+              'type' => 'path',
+              'url' => self::getPluginSourceDir() . '/tests/pkgs/gnocchi',
+              'options' => [
+                'symlink' => false,
+              ],
+            ],
             'test-rosti' => [
               'type' => 'path',
               'url' => self::getPluginSourceDir() . '/tests/pkgs/rosti',

--- a/tests/ScssPhpMethodTest.php
+++ b/tests/ScssPhpMethodTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Civi\CompilePlugin\Tests;
+
+use Composer\Plugin\PluginInterface;
+use ProcessHelper\ProcessHelper as PH;
+
+/**
+ * Class ScssPhpMethodTest
+ * @package Civi\CompilePlugin\Tests
+ *
+ * This is general integration test of the plugin. It uses a 'php-method'
+ * to compile some SCSS.
+ */
+class ScssPhpMethodTest extends IntegrationTestCase
+{
+
+    public static function getComposerJson()
+    {
+        $r = parent::getComposerJson() + [
+            'name' => 'test/patch-test',
+            'require' => [
+                'test/gnocchi' => '@dev',
+            ],
+            'minimum-stability' => 'dev',
+        ];
+        return $r;
+    }
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        self::initTestProject(static::getComposerJson());
+    }
+
+  /**
+   * When running 'composer install', it should generate 'jam.out' with suitable patches in place.
+   */
+    public function testComposerInstall()
+    {
+        $this->assertFileNotExists('vendor/test/gnocchi/build.css');
+
+        PH::runOk('COMPOSER_COMPILE=1 composer install -v');
+
+        $normalize = function ($s) {
+            return trim(preg_replace(';\s+;', ' ', $s));
+        };
+        $actual = $normalize(file_get_contents('vendor/test/gnocchi/build.css'));
+        $expected = $normalize(file_get_contents('vendor/test/gnocchi/build.css-expected'));
+        $this->assertNotEmpty($expected);
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/tests/pkgs/gnocchi/build.css-expected
+++ b/tests/pkgs/gnocchi/build.css-expected
@@ -1,0 +1,6 @@
+div .foo {
+        -ms-hyphens: auto;
+        -moz-hyphens: auto;
+        -webkit-hyphens: auto;
+        hyphens: auto;
+}

--- a/tests/pkgs/gnocchi/composer.json
+++ b/tests/pkgs/gnocchi/composer.json
@@ -1,0 +1,18 @@
+{
+    "authors": [
+        {
+            "name": "Tester McFakus",
+            "email": "tester@example.org"
+        }
+    ],
+    "name": "test/gnocchi",
+    "require": {
+        "civicrm/composer-compile-plugin": "@dev",
+        "scssphp/scssphp": "1.2.0",
+        "padaliyajay/php-autoprefixer": "~1.2"
+    },
+    "autoload": {"psr-4": {"ScssExample\\": "src"}},
+    "extra": {
+        "compile": [{"php-method": "\\ScssExample\\ScssExample::make"}]
+    }
+}

--- a/tests/pkgs/gnocchi/src/ScssExample.php
+++ b/tests/pkgs/gnocchi/src/ScssExample.php
@@ -1,0 +1,15 @@
+<?php
+namespace ScssExample;
+
+class ScssExample
+{
+    public static function make(array $task)
+    {
+        $pkgDir = dirname(__DIR__);
+        $scssCompiler = new \ScssPhp\ScssPhp\Compiler();
+        $scss = 'div { .foo { hyphens: auto; } }';
+        $css = $scssCompiler->compile($scss);
+        $autoprefixer = new \Padaliyajay\PHPAutoprefixer\Autoprefixer($css);
+        file_put_contents("$pkgDir/build.css", $autoprefixer->compile());
+    }
+}


### PR DESCRIPTION
This implements support for tasks based on `php-method` and fleshes out an example in the docs.

It includes an integration-test and fixes some bugs in the previous draft implementation.

To ensure correct class-loading (based on the target project's packages), the method is launched in a separate PHP sub-process.