### PR TITLE
Incremental compilation

### DIFF
--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -27,6 +27,7 @@ In `composer.json`, the `extra.compile` section may list multiple *tasks*. Each 
 | `active` | `bool` | `true` | Whether this task should be executed |
 | `title` | `string` | `my/pkg#pos` | Printable title display on the console. May be decorated with `<info>` and `<comment>` tags. |
 | `watch-files` | `string[]` | `[]` | List of files or directories which are used as input to this task. |
+| `out-files` | `string[]` | `[]` | List of files or directories which are created by this task. (Experimental) |
 
 The `run` property contains a list of steps to execute. Each step uses a prefix to indicate type. Here are some examples:
 
@@ -49,6 +50,10 @@ NOTE: Prior to v0.8, the `run` property did not exist - instead, there were sepa
 | -- | -- | -- |
 | `php-method` | `string` or `string[]` | PHP class+method. Multiple items may be given. Ex: `\MyModule\Compile::doCompilationStuff` |
 | `shell` | `string` or `string[]` | Bash statement to execute. Multiple items may be given Ex: `cat file1.txt file2.txt > file3.txt` |
+
+NOTE: If `watch-files` is given, then `composer compile:watch` will support live rebuilding.
+
+NOTE: If both `watch-files` and `out-files` are given, then `composer install` and `composer compile` will use the experimental support for incremental compilation. Incremental behavior may or may not be preserved in the future.
 
 NOTE: It is valid define new/unrecognized/bespoke fields. To avoid unintended conflicts in the future, bespoke fields should use a prefix.
 

--- a/src/Command/CompileCommand.php
+++ b/src/Command/CompileCommand.php
@@ -21,6 +21,7 @@ class CompileCommand extends \Composer\Command\BaseCommand
           ->setDescription('Run compilation tasks')
           ->addOption('all', null, InputOption::VALUE_NONE, 'Run all tasks, regardless of configuration')
           ->addOption('dry-run', 'N', InputOption::VALUE_NONE, 'Dry-run: Print a list of steps to be run')
+          ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force: Generate files even if the existing outputs look sufficiently fresh')
           ->addArgument('filterExpr', InputArgument::IS_ARRAY, 'Optional filter to match. Ex: \'vendor/package\' or \'vendor/package:id\'')
           ->setHelp(
               "Run compilation steps in all packages\n" .
@@ -36,7 +37,7 @@ class CompileCommand extends \Composer\Command\BaseCommand
         $taskList = new TaskList($this->getComposer(), $this->getIO());
         $taskList->load()->validateAll();
 
-        $taskRunner = new TaskRunner($this->getComposer(), $this->getIO());
+        $taskRunner = new TaskRunner($this->getComposer(), $this->getIO(), $input->getOption('force'));
         $filters = $input->getArgument('filterExpr');
         if ($input->getOption('all') && !empty($filters)) {
             throw new \InvalidArgumentException("The --all option does not accept filters.");

--- a/src/CompilePlugin.php
+++ b/src/CompilePlugin.php
@@ -104,7 +104,7 @@ class CompilePlugin implements PluginInterface, EventSubscriberInterface, Capabl
         $taskList = new TaskList($this->composer, $this->io);
         $taskList->load()->validateAll();
 
-        $taskRunner = new TaskRunner($this->composer, $this->io);
+        $taskRunner = new TaskRunner($this->composer, $this->io, false);
 
         if (empty($taskList->getAll())) {
             return;

--- a/src/Util/ComposerIoTrait.php
+++ b/src/Util/ComposerIoTrait.php
@@ -28,8 +28,8 @@ trait ComposerIoTrait
      * @param \Composer\IO\IOInterface $io
      */
     public function __construct(
-        \Composer\Composer $composer,
-        \Composer\IO\IOInterface $io
+        $composer,
+        $io
     ) {
         $this->composer = $composer;
         $this->io = $io;

--- a/src/Util/TsHelper.php
+++ b/src/Util/TsHelper.php
@@ -1,0 +1,90 @@
+<?php
+namespace Civi\CompilePlugin\Util;
+
+class TsHelper
+{
+
+    const SKIP = ';^(\.|\.\.|\.git|\.svn)$;';
+
+    use ComposerIoTrait;
+
+    /**
+     * Determine if $inputs are newer or older than $outputs.
+     *
+     * @param string|string[] $outputs
+     *   List of files or folders.
+     * @param string|string[] $inputs
+     *   List of files or folders.
+     * @return bool
+     *   TRUE if all mtime($outputs) are >= than all mtime($inputs).
+     *   FALSE if any mtime($outputs) are < than any mtime($inputs).
+     */
+    public function isFresh($outputs, $inputs)
+    {
+        // Enqueue a list of files from a subdir.
+        $addFiles = function (&$list, $dir) {
+            if ($dh = opendir($dir)) {
+                while (true) {
+                    $file = readdir($dh);
+                    if ($file === false) {
+                        break;
+                    } elseif (preg_match(self::SKIP, $file)) {
+                        // skip
+                    } else {
+                        $list[] = "$dir/$file";
+                    }
+                }
+                closedir($dh);
+            }
+        };
+
+        // We generally expect there to be more inputs than outputs.
+        // Therefore, we do the full-scan on outputs; the scan on inputs
+        // can short-circuit.
+
+        $inputs = (array)$inputs;
+        $outputs = (array)$outputs;
+        $maxOutputTs = null;
+        while (count($outputs) > 0) {
+            $output = array_shift($outputs);
+            if (!file_exists($output)) {
+                // Missing output, not fresh...
+                return false;
+            }
+            $outputTs = filemtime($output);
+            if ($maxOutputTs === null || $outputTs > $maxOutputTs) {
+                $maxOutputTs = $outputTs;
+            }
+            if (is_dir($output)) {
+                $addFiles($outputs, $output);
+            }
+        }
+
+        while (count($inputs) > 0) {
+            $input = array_shift($inputs);
+            if (file_exists($input)) {
+                $inputTs = filemtime($input);
+            } else {
+                if ($this->io) {
+                    $this->io->write("<warning>Task depends on non-existent input</warning>: " . $input);
+                }
+                $inputTs = time();
+            }
+
+            if ($maxOutputTs < $inputTs) {
+                return false;
+            }
+            if (is_dir($input)) {
+                $addFiles($inputs, $input);
+            }
+        }
+
+        return true;
+    }
+
+
+    public function clear()
+    {
+        clearstatcache();
+    }
+}

--- a/tests/TsHelperTest.php
+++ b/tests/TsHelperTest.php
@@ -1,0 +1,100 @@
+<?php
+namespace Civi\CompilePlugin\Tests;
+
+use Civi\CompilePlugin\Util\TsHelper;
+
+class TsHelperTest extends IntegrationTestCase
+{
+
+    const REFTIME = 1601521700;
+
+    public static function initTestProject($composerJson)
+    {
+        parent::initTestProject($composerJson);
+        $testDir = self::getTestDir();
+
+        mkdir("$testDir/input/sub1/sub2", 0777, true);
+        mkdir("$testDir/output/sub1/sub2", 0777, true);
+        $ps = [
+            "$testDir/input/sub1/sub2/one.src",
+            "$testDir/input/sub1/sub2/two.src",
+            "$testDir/output/sub1/sub2/one.bld",
+            "$testDir/output/sub1/sub2/two.bld",
+            "$testDir/output/sub1/sub2",
+            "$testDir/output/sub1",
+            "$testDir/output",
+            "$testDir/input/sub1/sub2",
+            "$testDir/input/sub1",
+            "$testDir/input",
+        ];
+        foreach ($ps as $p) {
+            touch($p, self::REFTIME);
+        }
+    }
+
+    public function testAddOutput()
+    {
+        self::initTestProject([]);
+        $testDir = self::getTestDir();
+
+        $fs = new TsHelper(null, null);
+        $this->assertTrue($fs->isFresh("$testDir/output", "$testDir/input"));
+
+        touch("$testDir/output/asdf");
+        $this->assertTrue($fs->isFresh("$testDir/output", "$testDir/input"));
+    }
+
+    public function testNonExistentOutput()
+    {
+        self::initTestProject([]);
+        $testDir = self::getTestDir();
+
+        $fs = new TsHelper(null, null);
+        $this->assertFalse($fs->isFresh(["$testDir/output", "$testDir/otherout"], "$testDir/input"));
+    }
+
+    public function testNonExistentInput()
+    {
+        self::initTestProject([]);
+        $testDir = self::getTestDir();
+
+        $fs = new TsHelper(null, null);
+        $this->assertFalse($fs->isFresh(["$testDir/output"], ["$testDir/input", "$testDir/other-in"]));
+    }
+
+    public function testAddInput()
+    {
+        self::initTestProject([]);
+        $testDir = self::getTestDir();
+
+        $fs = new TsHelper(null, null);
+        $this->assertTrue($fs->isFresh("$testDir/output", "$testDir/input"));
+
+        touch("$testDir/input/sub1/fdsa");
+        $this->assertFalse($fs->isFresh("$testDir/output", "$testDir/input"));
+    }
+
+    public function testUpdateInput()
+    {
+        self::initTestProject([]);
+        $testDir = self::getTestDir();
+
+        $fs = new TsHelper(null, null);
+        $this->assertTrue($fs->isFresh("$testDir/output", "$testDir/input"));
+
+        touch("$testDir/input/sub1/sub2/one.src");
+        $this->assertFalse($fs->isFresh("$testDir/output", "$testDir/input"));
+    }
+
+    public function testRenameDir()
+    {
+        self::initTestProject([]);
+        $testDir = self::getTestDir();
+
+        $fs = new TsHelper(null, null);
+        $this->assertTrue($fs->isFresh("$testDir/output", "$testDir/input"));
+
+        rename("$testDir/input/sub1", "$testDir/input/sububub");
+        $this->assertFalse($fs->isFresh("$testDir/output", "$testDir/input"));
+    }
+}


### PR DESCRIPTION
If you run `composer install` or `composer compile`, and if it has enough information about the inputs (`watch-files`) and outputs (`out-files`), then it will do a staleness check before compiling.
    
If we don't have enough information, then err on the side of recompiling too much.

I'm probably going to leave this sitting in a PR for a while because it adds some systemic complexity and I'm a little ambivalent about cost/benefit (maintenance/risk/performance/need/utility). Gonna let this marinate...