### PR TITLE
Verbose mode (-v) should imply that "PASSTHRU=always"

### DIFF
--- a/doc/site-build.md
+++ b/doc/site-build.md
@@ -81,5 +81,7 @@ or
 }
 ```
 
-If both the environment variable (`COMPOSER_COMPILE_PASSTHRU`) and the JSON option (`extra.compile-passthru`) are set, then
-the environment-variable takes precedence.
+Additionally, the verbose (`-v`) flag will enable `COMPOSER_COMPILE_PASSTHRU=always`.
+
+If the value is set in multiple ways, the order of preceduce (highest to lowest) is: (1) verbose flag (`-v`),
+(2) environment variable (`COMPOSER_COMPILE_PASSTHRU`), and (3) the JSON option (`extra.compile-passthru`).

--- a/src/Command/CompileCommand.php
+++ b/src/Command/CompileCommand.php
@@ -52,6 +52,10 @@ class CompileCommand extends \Composer\Command\BaseCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if ($output->isVerbose()) {
+            putenv('COMPOSER_COMPILE_PASSTHRU=always');
+        }
+
         $taskList = new TaskList($this->getComposer(), $this->getIO());
         $taskList->load()->validateAll();
 

--- a/src/Command/CompileWatchCommand.php
+++ b/src/Command/CompileWatchCommand.php
@@ -28,6 +28,10 @@ class CompileWatchCommand extends \Composer\Command\BaseCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if ($output->isVerbose()) {
+            putenv('COMPOSER_COMPILE_PASSTHRU=always');
+        }
+
         $intervalMicroseconds = 1000 * $input->getOption('interval');
         $watcher = $taskList = null;
         $stale = true;

--- a/src/TaskRunner.php
+++ b/src/TaskRunner.php
@@ -127,6 +127,21 @@ class TaskRunner
 
         $dryRunText = $isDryRun ? '<error>(DRY-RUN)</error> ' : '';
 
+        if (empty($tasks)) {
+            return;
+        }
+
+        switch ($this->getPassthruMode()) {
+            case 'never':
+            case 'error':
+                $io->write('<info>Compiling additional files</info> (<comment>For full details, use verbose "-v" mode.</comment>)');
+                break;
+
+            case 'always':
+                $io->write('<info>Compiling additional files</info>');
+                break;
+        }
+
         $tasks = $this->sortTasks($tasks);
         foreach ($tasks as $task) {
             /** @var \Civi\CompilePlugin\Task $task */


### PR DESCRIPTION
(1) When working on a dev task, it's surprising that `composer compile:watch -v`
doesn't give you subtask output, and it's little cumbersome to enter
`COMPOSER_COMPILE_PASSTHRU=always composer compile:watch`.

(2) Tangentially, since the default mode is moderately quiet/incomplete, we
should have sign-posts for developers encouraging use of `-v`.