### PR TITLE
PackageSorter - Add+fix SelfReferenceTest (Drupal 8.7.11)

### DIFF
--- a/tests/SelfReferenceTest.php
+++ b/tests/SelfReferenceTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Civi\CompilePlugin\Tests;
+
+use Civi\CompilePlugin\Event\CompileEvents;
+use ProcessHelper\ProcessHelper as PH;
+
+/**
+ * Class SelfReferenceTest
+ * @package Civi\CompilePlugin\Tests
+ *
+ * If a test package requires itself indirectly, then it might throw-off the PackageSorter.
+ */
+class SelfReferenceTest extends IntegrationTestCase
+{
+
+    public static function getComposerJson()
+    {
+        return parent::getComposerJson() + [
+          'name' => 'test/self-reference',
+          'require' => [
+              'civicrm/composer-compile-plugin' => '@dev',
+              'test/crypto-reference' => '*',
+          ],
+          'replace' => [
+              'test/crypto-reference' => 'self.version',
+          ],
+          'minimum-stability' => 'dev',
+          'extra' => [
+              'compile' => [
+                   [
+                      'title' => 'Compile first',
+                      'shell' => 'echo MARK: RUN FIRST',
+                   ],
+              ],
+          ],
+        ];
+    }
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        self::initTestProject(static::getComposerJson());
+    }
+
+    /**
+     * When running 'composer install', it run various events.
+     */
+    public function testComposerInstall()
+    {
+        $p = PH::runOk('COMPOSER_COMPILE_PASSTHRU=always COMPOSER_COMPILE=1 composer install');
+        $expectLines = [
+            "^MARK: RUN FIRST",
+        ];
+        $this->assertOutputLines($expectLines, ';^MARK:;', $p->getOutput());
+    }
+}


### PR DESCRIPTION
The CiviCRM CI threw up an error when installing on Drupal 8.7.11, which has a peculiar situation in the dependency-graph. The root package (`drupal/drupal`) both

* Replaces `drupal/core-file-cache`, and
* Requires `drupal/core-file-cache`

This patch makes two changes (one long, one short):

* (Long) Fully resolve aliases upfront, before sorting. To wit: `drupal/core-file-cache` should be treated as `drupal/drupal`.
* (Short) Skip self-requirements. To wit: it's silly for `drupal/drupal` to require `drupal/drupal`
