### PR TITLE
Adds circular reference test, dependency test and prefilters packages before sorting.

### DIFF
--- a/doc/develop.md
+++ b/doc/develop.md
@@ -87,8 +87,17 @@ for third party enhancements. These events are:
 * `pre-compile-task`: Fires before executing a specific `task`.
 * `post-compile-task`: Fires after executing a specific `task`.
 
-Note: The `compile` command supports a dry-run mode. All events will fire
-normally during dry-run. This is important to support subscribers which
-manipulate task definitions. However, if (hypothetically), a subscriber had
-some significant side-effects (like creating files), then it would be
-important to consult `$event->isDryRun()`.
+### pre/post-compile-list
+
+* The `-compile-list` events fire sometime after all packages are downloaded (but sometime before the tasks are executed).
+* The `-compile-list` events fire separately for each package.
+* Currently, there are some limitations in how packages are visited. (*If the limitations become problematic, they may change with only a minor version increment.*)
+    * The `-compile-list` events only fire for packages which have an explicit task-list. (*This may change to fire for all installed packages, even if they initially have an empty task-list.*)
+    * The order of visited packages is not guaranteed. Package A may fire before or after package B. (*This may change to some trivial but
+      reproducible ordering -- e.g. alphabetical.)
+
+### Tip: Dry Run
+
+The `compile` command supports a dry-run mode.  All events will fire normally during dry-run.  This is important to support subscribers
+which manipulate task definitions.  However, if (hypothetically), a subscriber had some significant side-effects (like creating files),
+then it would be important to consult `$event->isDryRun()`.

--- a/src/PackageSorter.php
+++ b/src/PackageSorter.php
@@ -7,7 +7,10 @@ class PackageSorter
 {
 
     /**
-     * Get the list of installed packages (sorted topologically).
+     * Given a list of installed packages sort such that dependant
+     * packages come after there dependencies.
+     *
+     * TODO handle cycles.
      *
      * @param PackageInterface[] $installedPackages
      *   All installed packages, including the root.

--- a/src/PackageSorter.php
+++ b/src/PackageSorter.php
@@ -2,6 +2,7 @@
 namespace Civi\CompilePlugin;
 
 use Composer\Package\PackageInterface;
+use Composer\Util\PackageSorter as ComposerPackageSorter;
 
 class PackageSorter
 {
@@ -20,93 +21,11 @@ class PackageSorter
      */
     public static function sortPackages($installedPackages)
     {
-        // We do our own topological sort.  It doesn't seem particularly easy to ask composer for this list -- the
-        // canonical sort for 'composer require' and 'composer update' have to address a lot of issues (like
-        // version-selection and already-installed packages) that don't make sense here.
-
-        // The topological sort may have multiple, equally-correct outputs. Given the same
-        // packages as input (regardless of input-order), we want to produce stable output.
-        usort($installedPackages, function ($a, $b) {
-            return strnatcmp($a->getName(), $b->getName());
-        });
-
-        // Index mapping all known aliases (provides/replaces) to real names.
-        // Array(string $logicalName => string $realName)
-        $realNames = [];
-        foreach ($installedPackages as $package) {
-            /** @var PackageInterface $package */
-            foreach ($package->getNames() as $alias) {
-                $realNames[$alias] = $package->getName();
-            }
-        }
-
-        // Array(string $realName => string[] $realNames)
-        $realRequires = [];
-        $addRealRequires = function ($package, $target) use (&$realRequires, &$realNames) {
-            if (isset($realNames[$target]) && $realNames[$target] !== $package) {
-                $realRequires[$package][] = $realNames[$target];
-            }
-        };
-        foreach ($installedPackages as $package) {
-            /** @var PackageInterface $package */
-            foreach ($package->getRequires() as $link) {
-                $addRealRequires($package->getName(), $link->getTarget());
-            }
-            // Unfortunately, cycles are common among suggests/dev-requires... ex: phpunit
-            //foreach ($package->getDevRequires() as $link) {
-            //    $addRealRequires($package->getName(), $link->getTarget());
-            //}
-            //foreach ($package->getSuggests() as $target => $comment) {
-            //    $addRealRequires($package->getName(), $target);
-            //}
-        }
-
-        // Unsorted list of packages that need to be visited.
-        // Array(string $packageName => PackageInterface $package).
-        $todoPackages = [];
-        foreach ($installedPackages as $package) {
-            $todoPackages[$package->getName()] = $package;
-        }
-
-        // The topologically sorted packages, from least-dependent to most-dependent.
-        // Array(string $packageName => PackageInterface $package)
-        $sortedPackages = [];
-
-        // A package is "ripe" when all its requirements are met.
-        $isRipe = function (PackageInterface $pkg) use (&$sortedPackages, &$realRequires) {
-            foreach ($realRequires[$pkg->getName()] ?? [] as $target) {
-                if (!isset($sortedPackages[$target])) {
-                     // printf("[%s] is not ripe due to [%s]\n", $pkg->getName(), $target);
-                    return false;
-                }
-            }
-            // printf("[%s] is ripe\n", $pkg->getName());
-            return true;
-        };
-
-        // A package is "consumed" when we move it from $todoPackages to $sortedPackages.
-        $consumePackage = function (PackageInterface $pkg) use (&$sortedPackages, &$todoPackages) {
-            $sortedPackages[$pkg->getName()] = $pkg;
-            unset($todoPackages[$pkg->getName()]);
-        };
-
-        // Main loop: Progressively move ripe packages from $todoPackages to $sortedPackages.
-        while (!empty($todoPackages)) {
-            $ripePackages = array_filter($todoPackages, $isRipe);
-            if (empty($ripePackages)) {
-                $todoStr = implode(' ', array_map(
-                    function ($p) {
-                        return $p->getName();
-                    },
-                    $todoPackages
-                ));
-                throw new \RuntimeException("Error: Failed to find next installable package. Remaining: $todoStr");
-            }
-            foreach ($ripePackages as $package) {
-                $consumePackage($package);
-            }
-        }
-
-        return array_keys($sortedPackages);
+        // We only want the order and the package names.
+        return array_map(function ($package ) {
+            return $package->getName();
+        },
+            ComposerPackageSorter::sortPackages($installedPackages)
+        );
     }
 }

--- a/src/PackageSorter.php
+++ b/src/PackageSorter.php
@@ -2,7 +2,6 @@
 namespace Civi\CompilePlugin;
 
 use Composer\Package\PackageInterface;
-use Composer\Util\PackageSorter as ComposerPackageSorter;
 
 class PackageSorter
 {
@@ -21,11 +20,93 @@ class PackageSorter
      */
     public static function sortPackages($installedPackages)
     {
-        // We only want the order and the package names.
-        return array_map(function ($package ) {
-            return $package->getName();
-        },
-            ComposerPackageSorter::sortPackages($installedPackages)
-        );
+        // We do our own topological sort.  It doesn't seem particularly easy to ask composer for this list -- the
+        // canonical sort for 'composer require' and 'composer update' have to address a lot of issues (like
+        // version-selection and already-installed packages) that don't make sense here.
+
+        // The topological sort may have multiple, equally-correct outputs. Given the same
+        // packages as input (regardless of input-order), we want to produce stable output.
+        usort($installedPackages, function ($a, $b) {
+            return strnatcmp($a->getName(), $b->getName());
+        });
+
+        // Index mapping all known aliases (provides/replaces) to real names.
+        // Array(string $logicalName => string $realName)
+        $realNames = [];
+        foreach ($installedPackages as $package) {
+            /** @var PackageInterface $package */
+            foreach ($package->getNames() as $alias) {
+                $realNames[$alias] = $package->getName();
+            }
+        }
+
+        // Array(string $realName => string[] $realNames)
+        $realRequires = [];
+        $addRealRequires = function ($package, $target) use (&$realRequires, &$realNames) {
+            if (isset($realNames[$target]) && $realNames[$target] !== $package) {
+                $realRequires[$package][] = $realNames[$target];
+            }
+        };
+        foreach ($installedPackages as $package) {
+            /** @var PackageInterface $package */
+            foreach ($package->getRequires() as $link) {
+                $addRealRequires($package->getName(), $link->getTarget());
+            }
+            // Unfortunately, cycles are common among suggests/dev-requires... ex: phpunit
+            //foreach ($package->getDevRequires() as $link) {
+            //    $addRealRequires($package->getName(), $link->getTarget());
+            //}
+            //foreach ($package->getSuggests() as $target => $comment) {
+            //    $addRealRequires($package->getName(), $target);
+            //}
+        }
+
+        // Unsorted list of packages that need to be visited.
+        // Array(string $packageName => PackageInterface $package).
+        $todoPackages = [];
+        foreach ($installedPackages as $package) {
+            $todoPackages[$package->getName()] = $package;
+        }
+
+        // The topologically sorted packages, from least-dependent to most-dependent.
+        // Array(string $packageName => PackageInterface $package)
+        $sortedPackages = [];
+
+        // A package is "ripe" when all its requirements are met.
+        $isRipe = function (PackageInterface $pkg) use (&$sortedPackages, &$realRequires) {
+            foreach ($realRequires[$pkg->getName()] ?? [] as $target) {
+                if (!isset($sortedPackages[$target])) {
+                     // printf("[%s] is not ripe due to [%s]\n", $pkg->getName(), $target);
+                    return false;
+                }
+            }
+            // printf("[%s] is ripe\n", $pkg->getName());
+            return true;
+        };
+
+        // A package is "consumed" when we move it from $todoPackages to $sortedPackages.
+        $consumePackage = function (PackageInterface $pkg) use (&$sortedPackages, &$todoPackages) {
+            $sortedPackages[$pkg->getName()] = $pkg;
+            unset($todoPackages[$pkg->getName()]);
+        };
+
+        // Main loop: Progressively move ripe packages from $todoPackages to $sortedPackages.
+        while (!empty($todoPackages)) {
+            $ripePackages = array_filter($todoPackages, $isRipe);
+            if (empty($ripePackages)) {
+                $todoStr = implode(' ', array_map(
+                    function ($p) {
+                        return $p->getName();
+                    },
+                    $todoPackages
+                ));
+                throw new \RuntimeException("Error: Failed to find next installable package. Remaining: $todoStr");
+            }
+            foreach ($ripePackages as $package) {
+                $consumePackage($package);
+            }
+        }
+
+        return array_keys($sortedPackages);
     }
 }

--- a/src/TaskList.php
+++ b/src/TaskList.php
@@ -37,10 +37,14 @@ class TaskList
     {
         $this->tasks = [];
         $this->sourceFiles = [];
-        $this->packageWeights = array_flip(PackageSorter::sortPackages(array_merge(
+        $allPackages = array_merge(
             $this->composer->getRepositoryManager()->getLocalRepository()->getCanonicalPackages(),
             [$this->composer->getPackage()]
-        )));
+        );
+        $compilePackages = $this->filterByHavingCompileTasks($allPackages);
+        $this->packageWeights = array_flip(PackageSorter::sortPackages(
+            $compilePackages
+        ));
 
         $rootPackage = $this->composer->getPackage();
         $localRepo = $this->composer->getRepositoryManager()->getLocalRepository();
@@ -56,6 +60,72 @@ class TaskList
         }
 
         return $this;
+    }
+
+    /**
+     * @param \Composer\Package\PackageInterface[] $installedPackages
+     * @return array
+     * List of installed packages (PackageInterface) with compilation tasks
+     */
+    protected function filterByHavingCompileTasks($installedPackages)
+    {
+        $rootPackage = $this->composer->getPackage();
+        $localRepo = $this->composer->getRepositoryManager()->getLocalRepository();
+        $packagesWithCompileTasks = [];
+
+        foreach ($installedPackages as $package) {
+            $path = '';
+            if ($package->getName() === $rootPackage->getName()) {
+                $installPath = realpath('.');
+                // I'm not a huge fan of using 'realpath()' here, but other tasks (using `getInstallPath()`)
+                // are effectively using `realpath()`, so we should be consistent.
+            } else {
+                $package = $localRepo->findPackage($package->getName(), '*');
+                $installPath = $this->composer->getInstallationManager()->getInstallPath($package);
+            }
+            if ($this->packageHasCompileTasks($package, $installPath)) {
+                $packagesWithCompileTasks[] = $package;
+            }
+        }
+        return $packagesWithCompileTasks;
+    }
+
+    /**
+     * @param \Composer\Package\PackageInterface $package
+     * @param string $installPath The package's location on disk.
+     * @return True if compile tasks are defined for this package.
+     */
+    protected function packageHasCompileTasks(PackageInterface $package, $installPath) {
+        $extra = null;
+
+        // Replicate behaviour from loadPackage which prefers
+        // composer.json on disk values over use of getExtra.
+
+        if (file_exists("$installPath/composer.json")) {
+            $json = json_decode(file_get_contents("$installPath/composer.json"), 1);
+            $extra = $json['extra'] ?? null;
+        }
+        if ($extra === null) {
+            $extra = $package->getExtra();
+        }
+        if (!empty($extra['compile'])) {
+            return TRUE;
+        }
+
+        if (empty($extra['compile-includes'])) {
+            return FALSE;
+        }
+
+        foreach ($extra['compile-includes'] as $includeFile) {
+            if (!file_exists($includePathFull) || !is_readable($includePathFull)) {
+                $this->io->writeError("<warning>Failed to read $includePathFull</warning>");
+                continue;
+            }
+            $inc = json_decode(file_get_contents($includePathFull), 1);
+            if (!empty($inc['compile'])) {
+                return TRUE;
+            }
+        }
     }
 
     /**

--- a/src/TaskList.php
+++ b/src/TaskList.php
@@ -95,7 +95,8 @@ class TaskList
      * @param string $installPath The package's location on disk.
      * @return True if compile tasks are defined for this package.
      */
-    protected function packageHasCompileTasks(PackageInterface $package, $installPath) {
+    protected function packageHasCompileTasks(PackageInterface $package, $installPath)
+    {
         $extra = null;
 
         // Replicate behaviour from loadPackage which prefers
@@ -109,11 +110,11 @@ class TaskList
             $extra = $package->getExtra();
         }
         if (!empty($extra['compile'])) {
-            return TRUE;
+            return true;
         }
 
         if (empty($extra['compile-includes'])) {
-            return FALSE;
+            return false;
         }
 
         foreach ($extra['compile-includes'] as $includeFile) {
@@ -124,7 +125,7 @@ class TaskList
             }
             $inc = json_decode(file_get_contents($includePathFull), 1);
             if (!empty($inc['compile'])) {
-                return TRUE;
+                return true;
             }
         }
     }

--- a/src/TaskList.php
+++ b/src/TaskList.php
@@ -117,6 +117,7 @@ class TaskList
         }
 
         foreach ($extra['compile-includes'] as $includeFile) {
+            $includePathFull = "$installPath/$includeFile";
             if (!file_exists($includePathFull) || !is_readable($includePathFull)) {
                 $this->io->writeError("<warning>Failed to read $includePathFull</warning>");
                 continue;

--- a/tests/CircularReferenceTest.php
+++ b/tests/CircularReferenceTest.php
@@ -47,7 +47,6 @@ class CircularReferenceTest extends IntegrationTestCase
               ],
           ],
         ];
-        var_export($returning);
         return $returning;
     }
 

--- a/tests/CircularReferenceTest.php
+++ b/tests/CircularReferenceTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Civi\CompilePlugin\Tests;
+
+use Civi\CompilePlugin\Event\CompileEvents;
+use ProcessHelper\ProcessHelper as PH;
+
+/**
+ * Class CircularReferenceTest
+ * @package Civi\CompilePlugin\Tests
+ *
+ * If there is a circular dependency graph in a test package, then it might throw-off the PackageSorter.
+ */
+class CircularReferenceTest extends IntegrationTestCase
+{
+
+    public static function getComposerJson()
+    {
+        $composer_json = parent::getComposerJson();
+        if (empty($composer_json['repositories'])) {
+            $composer_json['repositories'] = [];
+        }
+
+        $composer_json['repositories']['test-chicken'] = [
+              'type' => 'path',
+              'url' => self::getPluginSourceDir() . '/tests/pkgs/chicken',
+        ];
+        $composer_json['repositories']['test-egg'] = [
+              'type' => 'path',
+              'url' => self::getPluginSourceDir() . '/tests/pkgs/egg',
+        ];
+
+        $returning =  $composer_json + [
+          'name' => 'test/circular-reference',
+          'require' => [
+              'civicrm/composer-compile-plugin' => '@dev',
+              'test/chicken' => '*',
+              'test/egg' => '*',
+          ],
+          'minimum-stability' => 'dev',
+          'extra' => [
+              'compile' => [
+                   [
+                      'title' => 'Compile first',
+                      'shell' => 'echo MARK: RUN FIRST',
+                   ],
+              ],
+          ],
+        ];
+        var_export($returning);
+        return $returning;
+    }
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        self::initTestProject(static::getComposerJson());
+    }
+
+    /**
+     * When running 'composer install', it run various events.
+     */
+    public function testComposerInstall()
+    {
+        $p = PH::runOk('COMPOSER_COMPILE_PASSTHRU=always COMPOSER_COMPILE=1 composer install');
+        $expectLines = [
+            "^MARK: RUN FIRST",
+        ];
+        $this->assertOutputLines($expectLines, ';^MARK:;', $p->getOutput());
+    }
+}

--- a/tests/DependencyOrderTest.php
+++ b/tests/DependencyOrderTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Civi\CompilePlugin\Tests;
+
+use Civi\CompilePlugin\Event\CompileEvents;
+use ProcessHelper\ProcessHelper as PH;
+
+/**
+ * Class DependencyOrderTest
+ * @package Civi\CompilePlugin\Tests
+ *
+ * Test that checks that packages are sorted in a way that Dependant
+ * tasks are run first
+ */
+class DependencyOrderTest extends IntegrationTestCase
+{
+
+    public static function getComposerJson()
+    {
+        $composer_json = parent::getComposerJson();
+        
+        if (empty($composer_json['repositories'])) {
+            $composer_json['repositories'] = [];
+        }
+        $composer_json['repositories']['test-parent'] = [
+            'type' => 'path',
+            'url' => self::getPluginSourceDir() . '/tests/pkgs/parent',
+        ];
+        $composer_json['repositories']['test-child'] = [
+            'type' => 'path',
+              'url' => self::getPluginSourceDir() . '/tests/pkgs/child',
+        ];
+
+
+        $returning =  $composer_json + [
+          'name' => 'test/dependency-order-test',
+          'require' => [
+              'civicrm/composer-compile-plugin' => '@dev',
+              'test/parent' => '*',
+              'test/child' => '*',
+          ],
+          'minimum-stability' => 'dev',
+          'extra' => [
+              'compile' => [
+                   [
+                      'title' => 'Compile first',
+                      'shell' => 'echo MARK: RUN FIRST',
+                   ],
+              ],
+          ],
+        ];
+        return $returning;
+    }
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        self::initTestProject(static::getComposerJson());
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+        self::resetCompileFiles();
+    }
+
+    protected function tearDown()
+    {
+        self::resetCompileFiles();
+        parent::tearDown();
+    }
+
+
+    /**
+     * When running 'composer install', it runs various events.
+     */
+    public function testComposerInstall()
+    {
+        $this->assertFileNotExists(self::getPluginSourceDir() . '/tests/pkgs/parent/parent.out');
+        $this->assertFileNotExists(self::getPluginSourceDir() . '/tests/pkgs/child/child.out');
+        
+        $p = PH::runOk('COMPOSER_COMPILE=1 composer install');
+
+        $this->assertFileExists(self::getPluginSourceDir() . '/tests/pkgs/parent/parent.out');
+        $this->assertFileExists(self::getPluginSourceDir() . '/tests/pkgs/child/child.out');                
+    }
+
+    protected static function resetCompileFiles()
+    {
+        self::cleanFile(self::getPluginSourceDir() . '/tests/pkgs/parent/parent.out');
+        self::cleanFile(self::getPluginSourceDir() . '/tests/pkgs/child/child.out');
+    }
+}
+

--- a/tests/DependencyOrderTest.php
+++ b/tests/DependencyOrderTest.php
@@ -82,7 +82,7 @@ class DependencyOrderTest extends IntegrationTestCase
         $p = PH::runOk('COMPOSER_COMPILE=1 composer install');
 
         $this->assertFileExists(self::getPluginSourceDir() . '/tests/pkgs/parent/parent.out');
-        $this->assertFileExists(self::getPluginSourceDir() . '/tests/pkgs/child/child.out');                
+        $this->assertFileExists(self::getPluginSourceDir() . '/tests/pkgs/child/child.out');
     }
 
     protected static function resetCompileFiles()
@@ -91,4 +91,3 @@ class DependencyOrderTest extends IntegrationTestCase
         self::cleanFile(self::getPluginSourceDir() . '/tests/pkgs/child/child.out');
     }
 }
-

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -91,7 +91,8 @@ class EventTest extends IntegrationTestCase
 
     protected function startupLines()
     {
-        $pkgCount = 3;
+        // $pkgCount = 3; // All installed packages
+        $pkgCount = 1; // Only packages with predefined tasks
         $r = [];
         for ($i = 0; $i < $pkgCount; $i++) {
             $r[] = "^MARK: PRE_COMPILE_LIST";

--- a/tests/pkgs/chicken/composer.json
+++ b/tests/pkgs/chicken/composer.json
@@ -1,5 +1,5 @@
 {
-    "description": "(MOCK) Cherry jam implementation",
+    "description": "(MOCK) chicken implementation",
     "authors": [
         {
             "name": "Tester McFakus",

--- a/tests/pkgs/chicken/composer.json
+++ b/tests/pkgs/chicken/composer.json
@@ -1,0 +1,17 @@
+{
+    "description": "(MOCK) Cherry jam implementation",
+    "authors": [
+        {
+            "name": "Tester McFakus",
+            "email": "tester@example.org"
+        }
+    ],
+    "name": "test/chicken",
+    "provide": {
+        "test/chicken-implementation": "1.0.10"
+    },
+    "require": {
+        "test/egg": "*"
+    },
+    "minimum-stability": "dev"
+}

--- a/tests/pkgs/child/composer.json
+++ b/tests/pkgs/child/composer.json
@@ -1,0 +1,27 @@
+{
+    "description": "(MOCK) Child implementation",
+    "authors": [
+        {
+            "name": "Tester McFakus",
+            "email": "tester@example.org"
+        }
+    ],
+    "name": "test/child",
+    "provide": {
+        "test/child-implementation": "1.0.10"
+    },
+    "require": {
+	"civicrm/composer-compile-plugin": "@dev",
+	"test/parent": "*"
+    },
+    "minimum-stability": "dev",
+    "extra": {
+	"compile": [
+	    {
+		"tag": ["DependencyOrder"],
+		"title": "Child",
+		"shell": "pwd; if [ -f ../parent/parent.out ]; then echo ': Parent ran first' > child.out; fi"
+	    }
+	]
+    }
+}

--- a/tests/pkgs/egg/composer.json
+++ b/tests/pkgs/egg/composer.json
@@ -1,5 +1,5 @@
 {
-    "description": "(MOCK) Cherry jam implementation",
+    "description": "(MOCK) Egg implementation",
     "authors": [
 	{
 	    "name": "Tester McFakus",

--- a/tests/pkgs/egg/composer.json
+++ b/tests/pkgs/egg/composer.json
@@ -1,0 +1,17 @@
+{
+    "description": "(MOCK) Cherry jam implementation",
+    "authors": [
+	{
+	    "name": "Tester McFakus",
+	    "email": "tester@example.org"
+	}
+    ],
+    "name": "test/egg",
+    "provide": {
+	"test/egg-implementation": "1.0.0"
+    },
+    "require": {
+	"test/chicken": "*"
+    },
+    "minimum-stability": "dev"
+}

--- a/tests/pkgs/parent/composer.json
+++ b/tests/pkgs/parent/composer.json
@@ -1,0 +1,26 @@
+{
+    "description": "(MOCK) Parent implementation",
+    "authors": [
+        {
+            "name": "Tester McFakus",
+            "email": "tester@example.org"
+        }
+    ],
+    "name": "test/parent",
+    "provide": {
+        "test/parent-implementation": "1.0.10"
+    },
+    "requires" : {
+	"civicrm/composer-compile-plugin": "@dev"
+    },
+    "minimum-stability": "dev",
+    "extra": {
+	"compile": [
+	    {
+		"tag": ["DependencyOrder"],
+		"title": "Parent",
+		"shell": "pwd; echo 'PARENT' >> parent.out"
+	    }
+	]
+    }
+}


### PR DESCRIPTION
to address https://github.com/civicrm/composer-compile-plugin/issues/13

This checks what happens if adding a package A that requires package B that requires package A.