### PR TITLE
Fix for Composer 2 / PHP with thread safe disabled, putenv() doesn't work

### DIFF
--- a/src/TaskTransfer.php
+++ b/src/TaskTransfer.php
@@ -1,6 +1,8 @@
 <?php
 namespace Civi\CompilePlugin;
 
+use Composer\Util\Platform;
+
 /**
  * Class TaskTransfer
  * @package Civi\CompilePlugin
@@ -44,7 +46,7 @@ class TaskTransfer
     {
         $data = base64_encode(gzencode(json_encode($task->definition)));
         if (strlen($data) < self::MAX_ENV_SIZE) {
-            putenv(self::ENV_VAR . '=' . $data);
+            Platform::putEnv(self::ENV_VAR, $data);
         } else {
             $tempFile = tempnam(sys_get_temp_dir(), 'composer-compile-');
             file_put_contents($tempFile, json_encode($task->definition));

--- a/src/TaskTransfer.php
+++ b/src/TaskTransfer.php
@@ -46,7 +46,12 @@ class TaskTransfer
     {
         $data = base64_encode(gzencode(json_encode($task->definition)));
         if (strlen($data) < self::MAX_ENV_SIZE) {
-            Platform::putEnv(self::ENV_VAR, $data);
+            if (method_exists(Platform::class, 'putEnv')) {
+              Platform::putEnv(self::ENV_VAR, $data);
+            }
+            else {
+              putenv(self::ENV_VAR . '=' . $data);
+            }
         } else {
             $tempFile = tempnam(sys_get_temp_dir(), 'composer-compile-');
             file_put_contents($tempFile, json_encode($task->definition));


### PR DESCRIPTION
quick fix for issue 17: https://github.com/civicrm/composer-compile-plugin/issues/17

Probably not the end all of fixes wrt this, but makes it work. 