### PR TITLE
ComposerPassthru - Fix error when no options are passed through

### DIFF
--- a/src/Util/ComposerPassthru.php
+++ b/src/Util/ComposerPassthru.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Civi\CompilePlugin\Util;
 
 use Composer\Composer;
@@ -19,7 +20,6 @@ use Composer\IO\IOInterface;
  */
 class ComposerPassthru
 {
-
     use ComposerIoTrait {
         __construct as constructComposerIo;
     }
@@ -35,6 +35,7 @@ class ComposerPassthru
     public function __construct(Composer $composer, IOInterface $io)
     {
         $this->constructComposerIo($composer, $io);
+        $this->options = [];
         if ($io->isDecorated()) {
             $this->options[] = '--ansi';
         }
@@ -75,7 +76,7 @@ class ComposerPassthru
 
     protected function getPhpExecCommand()
     {
-        $d = new class($this->composer, $this->io) extends EventDispatcher
+        $d = new class ($this->composer, $this->io) extends EventDispatcher
         {
             public function exfiltratePhpExec()
             {


### PR DESCRIPTION
Example error below:

```
Generating autoload files
3 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
Error: implode(): Invalid arguments passed
In ComposerPassthru.php line 62:
  implode(): Invalid arguments passed
install [--prefer-source] [--prefer-dist] [--prefer-install PREFER-INSTALL] [--dry-run] [--dev] [--no-suggest] [--no-dev] [--no-autoloader] [--no-progress] [--no-install] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--apcu-autoloader-prefix APCU-AUTOLOADER-PREFIX] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--] [<packages>...]
Error: Process completed with exit code 1.
```