### PR TITLE
PHP8.4 Fix Deprecation on Implict nullable

### DIFF
--- a/src/Event/CompileListEvent.php
+++ b/src/Event/CompileListEvent.php
@@ -50,7 +50,7 @@ class CompileListEvent extends \Composer\EventDispatcher\Event
         \Composer\IO\IOInterface $io,
         \Composer\Package\PackageInterface $package,
         array $tasksSpecs,
-        array $tasks = null
+        ?array $tasks = null
     ) {
         parent::__construct($eventName);
         $this->io = $io;


### PR DESCRIPTION
This aims to fix the following PHP8.4 deprecation notice 

Deprecation Notice: Civi\CompilePlugin\Event\CompileListEvent::__construct(): Implicitly marking parameter $tasks as nullable is deprecated, the explicit nullable type must be used instead in /home/homer/buildkit/build/build-2/web/core/vendor/civicrm/composer-compile-plugin/src/Event/CompileListEvent.php:47