### PR TITLE
Update `Command` classes for Symfony 7 compatibility (#28)

### DIFF
--- a/src/Command/CompileCommand.php
+++ b/src/Command/CompileCommand.php
@@ -38,7 +38,7 @@ class CompileCommand extends \Composer\Command\BaseCommand
     protected function initialize(
         InputInterface $input,
         OutputInterface $output
-    ) {
+    ): void {
         $so = $input->getOption('soft-options');
         if ($so) {
             $json = json_decode(base64_decode($so), 1);

--- a/src/Command/CompileCommand.php
+++ b/src/Command/CompileCommand.php
@@ -6,6 +6,7 @@ use Civi\CompilePlugin\TaskList;
 use Civi\CompilePlugin\TaskRunner;
 use Civi\CompilePlugin\Util\EnvHelper;
 use Composer\Script\ScriptEvents;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -51,7 +52,7 @@ class CompileCommand extends \Composer\Command\BaseCommand
         parent::initialize($input, $output);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($output->isVerbose()) {
             EnvHelper::set('COMPOSER_COMPILE_PASSTHRU', 'always');
@@ -75,6 +76,6 @@ class CompileCommand extends \Composer\Command\BaseCommand
         } else {
             $taskRunner->runDefault($taskList, $input->getOption('dry-run'));
         }
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/CompileListCommand.php
+++ b/src/Command/CompileListCommand.php
@@ -5,6 +5,7 @@ namespace Civi\CompilePlugin\Command;
 use Civi\CompilePlugin\TaskList;
 use Civi\CompilePlugin\TaskRunner;
 use Civi\CompilePlugin\Util\TaskUIHelper;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -23,7 +24,7 @@ class CompileListCommand extends \Composer\Command\BaseCommand
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $taskList = new TaskList($this->getComposer(), $this->getIO());
         $taskList->load();
@@ -42,6 +43,6 @@ class CompileListCommand extends \Composer\Command\BaseCommand
         } else {
             $output->write(TaskUIHelper::formatTaskTable($tasks, ['active', 'id', 'title', 'action']));
         }
-        return 0;
+      return Command::SUCCESS;
     }
 }

--- a/src/Command/CompileWatchCommand.php
+++ b/src/Command/CompileWatchCommand.php
@@ -8,6 +8,7 @@ use Civi\CompilePlugin\Util\EnvHelper;
 use Civi\CompilePlugin\Util\ShellRunner;
 use Composer\EventDispatcher\ScriptExecutionException;
 use Lurker\ResourceWatcher;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -27,7 +28,7 @@ class CompileWatchCommand extends \Composer\Command\BaseCommand
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($output->isVerbose()) {
             EnvHelper::set('COMPOSER_COMPILE_PASSTHRU', 'always');
@@ -110,7 +111,7 @@ class CompileWatchCommand extends \Composer\Command\BaseCommand
             $output->writeln("Polling", OutputInterface::VERBOSITY_VERY_VERBOSE);
             $watcher->start($intervalMicroseconds, $intervalMicroseconds);
         }
-        return 0;
+      return Command::SUCCESS;
     }
 
     /**


### PR DESCRIPTION
Re-submission of @emembeka's #29, with re-base for current `master`.

(Note: We needed some toolchain maintenance (#30 etal). The test-matrix is back up, and it now reproduces the problem of #28 when testing with bleeding-edge version of `composer`, i.e. the `composer self-update --snapshot`. Hopefully, with a new run of the PR, we can see that patch fixing the test-failure. 🤞)